### PR TITLE
Implement async health check view

### DIFF
--- a/backend/config/views/health.py
+++ b/backend/config/views/health.py
@@ -1,5 +1,5 @@
 from django.http import JsonResponse
 
 
-def health_check(request):
+async def health_check(request):
     return JsonResponse({"status": "ok", "service": "backup_device"})


### PR DESCRIPTION
## Summary
- use an async Django view for `health_check`

## Testing
- `pre-commit run --files backend/config/views/health.py`
- `python backend/manage.py test` *(fails: ModuleNotFoundError: No module named 'django_ninja')*

------
https://chatgpt.com/codex/tasks/task_e_684b27070e3883238e349d971163cd32