### PR TITLE
Add dotenv loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# backup-device
+python (django) project to copy (and manage) media files from any device (mobiles, usb-drives) etc...
+
+## Environment variables
+
+The project uses [`python-dotenv`](https://pypi.org/project/python-dotenv/) to load environment variables from a `.env` file. The following line is included near the top of the main entry points:
+
+```python
+from dotenv import load_dotenv; load_dotenv()
+```
+
+This code is present in `manage.py`, `config/wsgi.py`, and `config/asgi.py`. Ensure a `.env` file exists before starting the application so that these environment variables are available.

--- a/backend/config/asgi.py
+++ b/backend/config/asgi.py
@@ -10,6 +10,9 @@ https://docs.djangoproject.com/en/4.2/howto/deployment/asgi/
 import os
 
 from django.core.asgi import get_asgi_application
+from dotenv import load_dotenv
+
+load_dotenv()
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
 

--- a/backend/config/wsgi.py
+++ b/backend/config/wsgi.py
@@ -10,6 +10,9 @@ https://docs.djangoproject.com/en/4.2/howto/deployment/wsgi/
 import os
 
 from django.core.wsgi import get_wsgi_application
+from dotenv import load_dotenv
+
+load_dotenv()
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
 

--- a/backend/manage.py
+++ b/backend/manage.py
@@ -3,6 +3,10 @@
 import os
 import sys
 
+from dotenv import load_dotenv
+
+load_dotenv()
+
 
 def main():
     """Run administrative tasks."""


### PR DESCRIPTION
## Summary
- load environment variables using `python-dotenv`
- document environment variable usage in README

## Testing
- `pre-commit run --files backend/manage.py backend/config/wsgi.py backend/config/asgi.py README.md`


------
https://chatgpt.com/codex/tasks/task_e_684b27509e088323b902495c4c1225ed